### PR TITLE
Исправлена ошибка с requestError и res.statusCode

### DIFF
--- a/06-mock/index.html
+++ b/06-mock/index.html
@@ -878,9 +878,12 @@ const url = 'https://api.weather.yandex.ru/v1/forecast';
         <pre class="js size-S"><code data-trim>
 function weather(cb) {
     request(url, (requestError, res, body) => {
-        if (requestError || res.statusCode !== 200) {
+        if (requestError) {
             return cb(requestError.message);
         }
+	if (res.statusCode !== 200) {
+	    return cb('Request failed')
+	}
 
         try {
             const data = JSON.parse(body);

--- a/06-mock/weather.js
+++ b/06-mock/weather.js
@@ -3,7 +3,11 @@ const url = 'https://api.weather.yandex.ru/v1/forecast';
 
 function weather(cb) {
     request(url, (requestError, res, body) => {
-        if (requestError || res.statusCode !== 200) {
+        if (requestError) {
+			return cb(requestError.message);
+		}
+		
+		if (res.statusCode !== 200) {
             return cb('Request failed');
         }
 


### PR DESCRIPTION
В ситуации, когда res.statusCode !== 200 переменная requestError будет undefined. 

Надо растащить эти проверки либо хитрее что-нибудь придумать. 
Я в домашке наткнулся на это просто.

Кстати, в следующей лекции тоже можно поправить. Многие же на них как на образец смотрят.